### PR TITLE
Add tests, output visualization

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,0 +1,52 @@
+# Adapted from https://github.com/actions-rs/meta/blob/master/recipes/quickstart.md,
+# removing the clippy step.
+# TODO add clippy
+
+on: [push, pull_request]
+
+name: Build and Test
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check

--- a/src/bin/render.rs
+++ b/src/bin/render.rs
@@ -13,11 +13,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     ls.stack(ram.clone()).unwrap();
     ls.heap(ram.clone()).unwrap();
     ls.boot_config(512, "fcb", flash.clone()).unwrap();
-    ls.vector_table(flash.clone(), Some(ram.clone())).unwrap();
-    ls.text(flash.clone(), Some(ram.clone())).unwrap();
-    ls.data(false, flash.clone(), Some(ram.clone())).unwrap();
+    ls.vector_table(ram.clone(), Some(flash.clone())).unwrap();
+    ls.text(flash.clone(), None).unwrap();
+    ls.data(false, ram.clone(), Some(flash.clone())).unwrap();
     ls.rodata(false, flash.clone(), None).unwrap();
-    ls.bss(false, flash.clone(), Some(ram.clone())).unwrap();
+    ls.bss(false, ram.clone(), Some(flash.clone())).unwrap();
     ls.write(&mut io::stdout().lock())
         .map_err(|err| Box::new(err) as _)
 }

--- a/src/bin/render.rs
+++ b/src/bin/render.rs
@@ -1,0 +1,23 @@
+//! Test tool to render a LinkerScript to `stdout`
+//!
+//! This might not represent a linker script that can be used on a
+//! device! But, it may help with visually inspecting the output.
+
+use imxrt_rt_gen::*;
+use std::io;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut ls = LinkerScript::<u32>::new();
+    let flash = ls.region(FLASH, 0x0, 512).unwrap();
+    let ram = ls.region(RAM, 0x20000000, 128).unwrap();
+    ls.stack(ram.clone()).unwrap();
+    ls.heap(ram.clone()).unwrap();
+    ls.boot_config(512, "fcb", flash.clone()).unwrap();
+    ls.vector_table(flash.clone(), Some(ram.clone())).unwrap();
+    ls.text(flash.clone(), Some(ram.clone())).unwrap();
+    ls.data(false, flash.clone(), Some(ram.clone())).unwrap();
+    ls.rodata(false, flash.clone(), None).unwrap();
+    ls.bss(false, flash.clone(), Some(ram.clone())).unwrap();
+    ls.write(&mut io::stdout().lock())
+        .map_err(|err| Box::new(err) as _)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -363,7 +363,7 @@ impl<W: Word> LinkerScript<W> {
     /// Generate a linker script and matching reset module
     /// which correctly initializes sections.
     pub fn generate(self) -> Result<()> {
-        const REQ_SEC_NAMES: [&str; 5] = ["stack", "vector_table", "text", "data", "bss"];
+        const REQ_SEC_NAMES: [&str; 6] = ["stack", "vector_table", "text", "data", "rodata", "bss"];
         for req_sec_name in REQ_SEC_NAMES.iter() {
             let name = String::from(*req_sec_name);
             if !self.sections.contains_key(&name) {
@@ -397,5 +397,95 @@ mod tests {
         ls.rodata(false, flash.clone(), None).unwrap();
         ls.bss(false, flash.clone(), Some(ram.clone())).unwrap();
         ls.generate().unwrap();
+    }
+
+    //
+    // The 'rejects_*' tests show that we reject linker scripts that are missing
+    // our required sections.
+    //
+
+    #[derive(PartialEq, Eq)]
+    enum Required {
+        Stack,
+        VectorTable,
+        Text,
+        Data,
+        ROData,
+        Bss,
+    }
+
+    impl ToString for Required {
+        fn to_string(&self) -> String {
+            ToString::to_string(match self {
+                Required::Stack => "stack",
+                Required::VectorTable => "vector_table",
+                Required::Text => "text",
+                Required::Data => "data",
+                Required::ROData => "rodata",
+                Required::Bss => "bss",
+            })
+        }
+    }
+
+    fn reject_missing(required: Required) {
+        let mut ls = LinkerScript::<u32>::new();
+        let flash = ls.region(FLASH, 0x0, 512).unwrap();
+        let ram = ls.region(RAM, 0x20000000, 128).unwrap();
+        if Required::Stack != required {
+            ls.stack(ram.clone()).unwrap();
+        }
+        if Required::VectorTable != required {
+            ls.vector_table(flash.clone(), Some(ram.clone())).unwrap();
+        }
+        if Required::Text != required {
+            ls.text(flash.clone(), Some(ram.clone())).unwrap();
+        }
+        if Required::Data != required {
+            ls.data(false, flash.clone(), Some(ram.clone())).unwrap();
+        }
+        if Required::ROData != required {
+            ls.rodata(false, flash.clone(), None).unwrap();
+        }
+        if Required::Bss != required {
+            ls.bss(false, flash.clone(), Some(ram.clone())).unwrap();
+        }
+        match ls.generate() {
+            Err(LinkerError::MissingSection(section)) if section == required.to_string() => {}
+            result => panic!(
+                "Expected missing {}, but got {:?}",
+                required.to_string(),
+                result
+            ),
+        };
+    }
+
+    #[test]
+    fn rejects_missing_vector_table() {
+        reject_missing(Required::VectorTable);
+    }
+
+    #[test]
+    fn rejects_missing_stack() {
+        reject_missing(Required::Stack);
+    }
+
+    #[test]
+    fn rejects_missing_text() {
+        reject_missing(Required::Text);
+    }
+
+    #[test]
+    fn rejects_missing_data() {
+        reject_missing(Required::Data);
+    }
+
+    #[test]
+    fn rejects_missing_rodata() {
+        reject_missing(Required::ROData);
+    }
+
+    #[test]
+    fn rejects_missing_bss() {
+        reject_missing(Required::Bss);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -362,7 +362,16 @@ impl<W: Word> LinkerScript<W> {
 
     /// Generate a linker script and matching reset module
     /// which correctly initializes sections.
+    ///
+    /// The function places a linker script file, called `link.x`, in
+    /// the current working directory.
     pub fn generate(self) -> Result<()> {
+        let mut link_x = File::create("link.x")?;
+        self.write(&mut link_x)
+    }
+
+    /// Write the linker script into the writer, `link_x`
+    pub fn write<Wr: Write>(self, link_x: &mut Wr) -> Result<()> {
         const REQ_SEC_NAMES: [&str; 6] = ["stack", "vector_table", "text", "data", "rodata", "bss"];
         for req_sec_name in REQ_SEC_NAMES.iter() {
             let name = String::from(*req_sec_name);
@@ -372,7 +381,6 @@ impl<W: Word> LinkerScript<W> {
         }
         let link = generate::link::render(&self)?;
         //let reset = generate::reset::render(&self)?;
-        let mut link_x = File::create("link.x")?;
         //let mut reset_rs = File::create("reset.rs")?;
         link_x.write_all(&link)?;
         //reset_rs.write_all(&reset)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -379,12 +379,11 @@ impl<W: Word> LinkerScript<W> {
                 return Err(LinkerError::MissingSection(name));
             }
         }
-        let link = generate::link::render(&self)?;
+        generate::link::render(&self, link_x)?;
+        Ok(())
         //let reset = generate::reset::render(&self)?;
         //let mut reset_rs = File::create("reset.rs")?;
-        link_x.write_all(&link)?;
         //reset_rs.write_all(&reset)?;
-        Ok(())
     }
 }
 


### PR DESCRIPTION
Added some tests during my first review. Also, added a quick binary so that I could visualize the generated linker script. Run

```
cargo run --bin render
```

to see what `LinkerScript` produces.